### PR TITLE
Add container name for logs

### DIFF
--- a/bin/kube-status
+++ b/bin/kube-status
@@ -79,19 +79,16 @@ get_app_name()
     echo $app_name
 }
 
-get_logs()
-{
-  KUBE_OPTS=""
-  if [ "$MULTIPLE_CONTAINER_PODS" == "true" ]; then
-    KUBE_OPTS="$KUBE_OPTS --container=$(get_app_name "$1")"
-  fi
+get_logs() {
+	KUBE_OPTS=""
+	KUBE_OPTS="$KUBE_OPTS --container=$(get_app_name "$1")"
 
-  log_file_name=$2
-  if [ "$log_file_name" == "stdout" ]; then
-    $KUBECTL logs $1 --tail $3 --namespace=$4 $KUBE_OPTS
-  else
-    $KUBECTL exec  $1 --namespace=$4 $KUBE_OPTS -- tail -n $3 $log_file_name
-  fi
+	log_file_name=$2
+	if [ "$log_file_name" == "stdout" ]; then
+		$KUBECTL logs $1 --tail $3 --namespace=$4 $KUBE_OPTS
+	else
+		$KUBECTL exec $1 --namespace=$4 $KUBE_OPTS -- tail -n $3 $log_file_name
+	fi
 }
 
 get_pods()


### PR DESCRIPTION
Fetching logs from a Istio enabled namespaces requires specifying a container name.