### PR TITLE
Added activeadmin addons gem which enables lots of add ons like select2, datepicker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'tzinfo-data', platforms: [:jruby]
 gem 'devise', git: 'https://github.com/plataformatec/devise'
 gem 'simple_token_authentication', '~> 1.0'
 gem 'activeadmin', '~> 1.1.0'
+gem 'activeadmin_addons'
 gem "kaminari", "~> 1.0.0"
 gem 'browserify-rails'
 gem 'devise-two-factor', '~> 3.0.0' # for two factor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_material (1.5.2)
     activeadmin (1.1.0)
       arbre (>= 1.1.1)
       coffee-rails
@@ -47,6 +48,13 @@ GEM
       ransack (~> 1.3)
       sass (~> 3.1)
       sprockets (< 4.1)
+    activeadmin_addons (1.9.0)
+      active_material
+      railties
+      require_all
+      sassc
+      sassc-rails
+      xdan-datetimepicker-rails (~> 2.5.1)
     activejob (5.0.7.2)
       activesupport (= 5.0.7.2)
       globalid (>= 0.3.6)
@@ -123,7 +131,7 @@ GEM
     factory_girl_rails (4.9.0)
       factory_girl (~> 4.9.0)
       railties (>= 3.0.0)
-    ffi (1.10.0)
+    ffi (1.15.5)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
@@ -280,6 +288,14 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sexp_processor (4.12.0)
     simple_token_authentication (1.15.1)
       actionmailer (>= 3.2.6, < 6)
@@ -321,12 +337,16 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xdan-datetimepicker-rails (2.5.4)
+      jquery-rails
+      rails (>= 3.2.16)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activeadmin (~> 1.1.0)
+  activeadmin_addons
   acts_as_paranoid
   amoeba (~> 3.1.0)
   audited (~> 4.5)

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -1,1 +1,2 @@
 #= require active_admin/base
+#= require activeadmin_addons/all

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -1,3 +1,4 @@
+@import 'activeadmin_addons/all';
 // SASS variable overrides must be declared before loading up Active Admin's styles.
 //
 // To view the variables that Active Admin provides, take a look at

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -119,7 +119,7 @@ ActiveAdmin.setup do |config|
   # This allows your users to comment on any resource registered with Active Admin.
   #
   # You can completely disable comments:
-  # config.comments = false
+  config.comments = false
   #
   # You can change the name under which comments are registered:
   # config.comments_registration_name = 'AdminComment'

--- a/config/initializers/activeadmin_addons.rb
+++ b/config/initializers/activeadmin_addons.rb
@@ -1,0 +1,12 @@
+ActiveadminAddons.setup do |config|
+  # Change to "default" if you want to use ActiveAdmin's default select control.
+  # config.default_select = "select2"
+
+  # Set default options for DateTimePickerInput. The options you can provide are the same as in
+  # xdan's datetimepicker library (https://github.com/xdan/datetimepicker/tree/2.5.4). Yo need to
+  # pass a ruby hash, avoid camelCase keys. For example: use min_date instead of minDate key.
+  # config.datetime_picker_default_options = {}
+
+  # Set DateTimePickerInput input format. This if for backend (Ruby)
+  # config.datetime_picker_input_format = "%Y-%m-%d %H:%M"
+end


### PR DESCRIPTION
We were facing lots of issues while searching a particular publisher or user from a select box.  To overcome that issue, i have
added activeadmin addons gem which enables lots of add ons like select2, datepicker - 

link: https://github.com/platanus/activeadmin_addons

Now select2 will apply to all the dropdowns and it will look like below
<img width="1436" alt="Screenshot 2022-04-05 at 4 46 31 PM" src="https://user-images.githubusercontent.com/16555538/161742560-dca929e8-a310-40c5-b472-3e380be2ecc2.png">
